### PR TITLE
Read configuration toml from standard input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "photofinish"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "clap",
  "reqwest",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, io::{self, Read}};
 
 #[derive(Debug)]
 pub struct Scenario {
@@ -7,15 +7,41 @@ pub struct Scenario {
     pub directories: Vec<String>,
 }
 
+fn get_config_from_stdin() -> String {
+    let mut piped_input = String::new();
+    match io::stdin().read_to_string(&mut piped_input) {
+        Ok(len) => {
+            if len != 0 {
+                return piped_input;
+            }
+            String::new()
+        },
+        Err(error) => {
+            println!("Error! could not read from stdin the photofinish config file\n: {}", error);
+            String::new()
+        }
+    }
+}
+
 pub fn get_config_file_content() -> String {
     match fs::read_to_string(".photofinish.toml") {
-        Ok(toml_content) => toml_content,
+        Ok(toml_content) => {
+            println!("read from config file!\n");
+
+            return toml_content
+        },
         Err(err) => {
-            println!(
-                "Error! Probably .photofinish.toml is missing\n{}",
-                err
-            );
-            String::new()
+            let piped_config = get_config_from_stdin();
+
+            if piped_config == "" {
+                println!(
+                    "Error! Probably .photofinish.toml is missing\n{}",
+                    err
+                );
+                return String::new()
+            }
+            
+            piped_config
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,10 +11,10 @@ fn get_config_from_stdin() -> String {
     let mut piped_input = String::new();
     match io::stdin().read_to_string(&mut piped_input) {
         Ok(len) => {
-            if len != 0 {
-                return piped_input;
+            match len {
+                0 => String::new(),
+                _ => piped_input
             }
-            String::new()
         },
         Err(error) => {
             println!("Error! could not read from stdin the photofinish config file\n: {}", error);
@@ -25,23 +25,20 @@ fn get_config_from_stdin() -> String {
 
 pub fn get_config_file_content() -> String {
     match fs::read_to_string(".photofinish.toml") {
-        Ok(toml_content) => {
-            println!("read from config file!\n");
-
-            return toml_content
-        },
+        Ok(toml_content) => toml_content,
         Err(err) => {
             let piped_config = get_config_from_stdin();
 
-            if piped_config == "" {
-                println!(
-                    "Error! Probably .photofinish.toml is missing\n{}",
-                    err
-                );
-                return String::new()
+            match piped_config.as_str() {
+                "" => {
+                    println!(
+                        "Error! Probably .photofinish.toml is missing\n{}",
+                        err
+                    );
+                    String::new()
+                },
+                _ => piped_config
             }
-            
-            piped_config
         }
     }
 }


### PR DESCRIPTION
Add as option, when the toml file is missing, the ability to read configuration toml from stdin.

This is meant to be used with pipes.