### PR TITLE
Add exit codes to the tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
 name = "fastrand"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +534,7 @@ name = "photofinish"
 version = "1.2.2"
 dependencies = [
  "clap",
+ "exitcode",
  "reqwest",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ clap = {version = "3.0.7", features = ["cargo"] }
 serde = { version = "1.0", features = ["derive"] }
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
+exitcode = "1.1.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate clap;
+extern crate exitcode;
 
 use clap::{App, Arg};
 
@@ -40,12 +41,19 @@ async fn main() {
 
     if options.subcommand_matches("list").is_some() {
         list::show_list(&scenarios);
+        std::process::exit(exitcode::OK)
     }
 
     if let Some(run_options) = options.subcommand_matches("run") {
         let scenario_label = run_options.value_of("SET").unwrap();
         let endpoint_url = run_options.value_of("url").unwrap();
         let api_key = run_options.value_of("API_KEY").unwrap();
-        run::run(endpoint_url, api_key, scenario_label.to_string(), scenarios).await;
+        match run::run(endpoint_url, api_key, scenario_label.to_string(), scenarios).await {
+            Ok(()) => std::process::exit(exitcode::OK),
+            Err(()) => std::process::exit(1)
+        }
     }
+
+    println!("Subcommand not provided. Available subcommands: list|run");
+    std::process::exit(exitcode::USAGE)
 }


### PR DESCRIPTION
Add exit codes to the tool. It doesn't change much the logic, except it handles the unauthorized scenario. When one unauthorized error is received, the execution finishes, as the rest will have the same result.
All remaining errors are not treated, and it still returns 0 exit code.
- Everything OK -> 0
- Unauthorized/Non existing scenario -> 1
- Subcommand not used -> 64

PD: I just was bored, so I thought on doing this. We can entirely ditch if it is so bad hehe