### PR TITLE
Update to Rust 1.76 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59 as builder
+FROM rust:1.76 as builder
 
 WORKDIR /home/photofinish/
 


### PR DESCRIPTION
As above, an old version of Rust threw an error due to dependencies "too fresh" for it.