### PR TITLE
Enforce operation order

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Photofinish reads a `.photofinish.toml` file in the current working directory an
 ## Usage
 
 ```sh
-$ photofinish run help
-photofinish-run
+$ photofinish run --help
+photofinish-run 
 injects a specific set of events
 
 USAGE:
@@ -24,6 +24,7 @@ ARGS:
 OPTIONS:
     -h, --help         Print help information
     -u, --url <url>    [default: http://localhost:8081/api/collect]
+    -w <wait>          Wait interval between http requests, in milliseconds [default: 0]
 ```
 
 Please refer to `photofinish help` for more commands.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,7 @@
-use std::{fs, io::{self, Read}};
+use std::{
+    fs,
+    io::{self, Read},
+};
 
 #[derive(Debug)]
 pub struct Scenario {
@@ -10,14 +13,15 @@ pub struct Scenario {
 fn get_config_from_stdin() -> String {
     let mut piped_input = String::new();
     match io::stdin().read_to_string(&mut piped_input) {
-        Ok(len) => {
-            match len {
-                0 => String::new(),
-                _ => piped_input
-            }
+        Ok(len) => match len {
+            0 => String::new(),
+            _ => piped_input,
         },
         Err(error) => {
-            println!("Error! could not read from stdin the photofinish config file\n: {}", error);
+            println!(
+                "Error! could not read from stdin the photofinish config file\n: {}",
+                error
+            );
             String::new()
         }
     }
@@ -31,13 +35,10 @@ pub fn get_config_file_content() -> String {
 
             match piped_config.as_str() {
                 "" => {
-                    println!(
-                        "Error! Probably .photofinish.toml is missing\n{}",
-                        err
-                    );
+                    println!("Error! Probably .photofinish.toml is missing\n{}", err);
                     String::new()
-                },
-                _ => piped_config
+                }
+                _ => piped_config,
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,13 @@ async fn main() {
                         .help("API key for the remote endpoint")
                         .default_value("")
                         .required(false),
+                )
+                .arg(
+                    Arg::new("wait")
+                        .short('w')
+                        .help("Wait interval between http requests, in milliseconds")
+                        .default_value("0")
+                        .required(false),
                 ),
         )
         .get_matches();
@@ -47,8 +54,18 @@ async fn main() {
     if let Some(run_options) = options.subcommand_matches("run") {
         let scenario_label = run_options.value_of("SET").unwrap();
         let endpoint_url = run_options.value_of("url").unwrap();
+        let wait = run_options.value_of("wait").unwrap();
         let api_key = run_options.value_of("API_KEY").unwrap();
-        match run::run(endpoint_url, api_key, scenario_label.to_string(), scenarios).await {
+
+        match run::run(
+            endpoint_url,
+            api_key,
+            scenario_label.to_string(),
+            scenarios,
+            wait.parse::<u64>().unwrap(),
+        )
+        .await
+        {
             Ok(()) => std::process::exit(exitcode::OK),
             Err(()) => std::process::exit(1)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ async fn main() {
         .await
         {
             Ok(()) => std::process::exit(exitcode::OK),
-            Err(()) => std::process::exit(1)
+            Err(()) => std::process::exit(1),
         }
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -101,8 +101,8 @@ pub async fn run(
     match selected_scenario {
         None => {
             println!("Non-existing scenario!");
-            return Err(())
-        },
+            return Err(());
+        }
         Some(scenario) => {
             let mut fixtures_in_directories: Vec<String> = scenario
                 .directories
@@ -123,9 +123,7 @@ pub async fn run(
                         retryable.push(FixtureResult::Retryable { file })
                     }
                     Ok(FixtureResult::Skippable | FixtureResult::Success) => (),
-                    Ok(FixtureResult::Unauthorized) => {
-                        return Err(())
-                    },
+                    Ok(FixtureResult::Unauthorized) => return Err(()),
                     Err(Errored { file, reason }) => {
                         println!("An error occurred in loading fixture {}: {}", file, reason)
                     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,6 +1,7 @@
 use crate::config::Scenario;
 use reqwest::StatusCode;
-use std::{fs, thread};
+use std::fs;
+use tokio::time::sleep;
 
 #[derive(Debug)]
 enum FixtureResult {
@@ -129,7 +130,7 @@ pub async fn run(
                     }
                 }
 
-                thread::sleep(std::time::Duration::from_millis(wait));
+                sleep(std::time::Duration::from_millis(wait)).await
             }
 
             for to_retry in retryable.iter() {


### PR DESCRIPTION
Enforce the order of execution of the HTTP requests by sorting the fixture set by file name. Optionally, a `wait` argument can be provided to add a delay between HTTP requests.

**_Rationale_**
As this is a tool for replaying events, I expect the ability to define the order in which events should be processed; following the alphabetical order of the files in the directory seems to be the more natural approach.
Furthermore, the `wait` parameter can slow down the ingestion rate for the receiving service, if needed.