### PR TITLE
Upgrade github actions runner ubuntu version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v1

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [v1.4.2](https://github.com/trento-project/photofinish/tree/v1.4.2) (2025-03-04)
+
+[Full Changelog](https://github.com/trento-project/photofinish/compare/v1.4.1...v1.4.2)
+
+- Release 1.4.2 building the image in Ubuntu 24.04
+
+## [v1.4.1](https://github.com/trento-project/photofinish/tree/v1.4.1) (2024-11-11)
+
+[Full Changelog](https://github.com/trento-project/photofinish/compare/v1.4.0...v1.4.1)
+
+- Release 1.4.1 [\#24](https://github.com/trento-project/photofinish/pull/24) ([balanza](https://github.com/balanza))
+
+## [v1.4.0](https://github.com/trento-project/photofinish/tree/v1.4.0) (2024-11-11)
+
+[Full Changelog](https://github.com/trento-project/photofinish/compare/v1.3.0...v1.4.0)
+
+- Enforce operation order [\#23](https://github.com/trento-project/photofinish/pull/23) ([balanza](https://github.com/balanza))
+
 ## [v1.3.0](https://github.com/trento-project/photofinish/tree/v1.3.0) (2024-03-18)
 
 [Full Changelog](https://github.com/trento-project/photofinish/compare/v1.2.2...v1.3.0)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "photofinish"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "clap",
  "exitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photofinish"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# Description

Upgrade github actions runner ubuntu version.
I'm bumping the package version even though it doesn't include any new feature. As we will build the package with a new ubuntu version, and this must be used by the same ubuntu version, I will create a release afterwards, so we can pin the download to this version, and to the correct binary afterall

https://github.com/actions/runner-images/issues/11101