### PR TITLE
[TRNT-4317] Pin GHA to SHA instead of tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           push: true # Will only build if this is not here
           tags: |

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -12,11 +12,11 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Build
       run: cargo build --release
     - name: Compress action step
-      uses: a7ul/tar-action@v1.1.0
+      uses: a7ul/tar-action@6b2b13625a2e286a0a04950810139961bf8ce00d # v1.1.0
       id: compress
       with:
         command: c
@@ -25,6 +25,6 @@ jobs:
           ./photofinish
         outPath: photofinish_linux_x86_64.tar.gz
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       with:
         files: ./photofinish_linux_x86_64.tar.gz

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Build
       run: cargo build --release
     - name: Run tests


### PR DESCRIPTION
# Description

As security incidents are popping up constantly, it is a good practice to pin the GHA to a specific SHA instead of tags, in case the GHA repository gets compromised. This PR replaces all the versions with the specific SHA.

Related # TRNT-4317


```
==> Summary
    Total uses: references found : 7
    Already pinned (SHA)         : 0
    Pinned in this run           : 7
    Resolved from cache          : 1
    Hardcoded overrides applied  : 0
    Private/inaccessible (logged): 0
    Failed to resolve            : 0
```

## How was this tested?

N/A

