### PR TITLE
Allow sending extra HTTP headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "photofinish"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "clap",
  "exitcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "photofinish"
-version = "1.4.2"
+version = "1.5.0"
 edition = "2024"
 
 [dependencies]

--- a/README.adoc
+++ b/README.adoc
@@ -27,6 +27,7 @@ OPTIONS:
     -k, --insecure <insecure>    Skip SSL verification [default: false]
     -u, --url <url>              [default: http://localhost:8081/api/collect]
     -w <wait>                    Wait interval between http requests, in milliseconds [default: 0]
+    -H, --header <header>        Extra HTTP header to send with each request, as 'Key: Value'. Can be repeated.
 ----
 
 Please refer to `+photofinish help+` for more commands.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 extern crate clap;
 extern crate exitcode;
 
-use clap::{Arg, Command};
+use clap::{ArgAction, Arg, Command};
 
 mod config;
 mod list;
@@ -51,6 +51,14 @@ async fn main() {
                         .help("Wait interval between http requests, in milliseconds")
                         .default_value("0")
                         .required(false),
+                )
+                .arg(
+                    Arg::new("header")
+                        .short('H')
+                        .long("header")
+                        .help("Extra HTTP header to send with each request, as 'Key: Value'. Can be repeated.")
+                        .action(ArgAction::Append)
+                        .required(false),
                 ),
         )
         .get_matches();
@@ -70,6 +78,10 @@ async fn main() {
         let insecure = run_options.get_one::<String>("insecure").unwrap();
         let wait = run_options.get_one::<String>("wait").unwrap();
         let api_key = run_options.get_one::<String>("API_KEY").unwrap();
+        let headers: Vec<&str> = run_options
+            .get_many::<String>("header")
+            .map(|values| values.map(String::as_str).collect())
+            .unwrap_or_default();
 
         match run::run(
             endpoint_url,
@@ -78,6 +90,7 @@ async fn main() {
             scenario_label.to_string(),
             scenarios,
             wait.parse::<u64>().unwrap(),
+            &headers,
         )
         .await
         {

--- a/src/run.rs
+++ b/src/run.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Scenario;
+use reqwest::header::{HeaderName, HeaderValue};
 use reqwest::{ClientBuilder, StatusCode};
 use std::fs;
 use tokio::time::sleep;
@@ -41,7 +42,17 @@ async fn post_fixture(
             for raw_header in extra_headers {
                 match raw_header.split_once(':') {
                     Some((name, value)) => {
-                        request = request.header(name.trim(), value.trim());
+                        let header_name = HeaderName::from_bytes(name.trim().as_bytes());
+                        let header_value = HeaderValue::from_str(value.trim());
+                        match (header_name, header_value) {
+                            (Ok(header_name), Ok(header_value)) => {
+                                request = request.header(header_name, header_value);
+                            }
+                            _ => println!(
+                                "Ignoring invalid header '{}', name/value is not a valid HTTP header",
+                                raw_header
+                            ),
+                        }
                     }
                     None => println!(
                         "Ignoring malformed header '{}', expected format 'Key: Value'",
@@ -428,8 +439,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_fixture_ignores_malformed_headers() {
-        let dir = unique_test_dir("post_malformed_headers");
+    async fn post_fixture_ignores_invalid_headers_without_failing_the_request() {
+        let dir = unique_test_dir("post_invalid_headers");
         let file = dir.join("fixture.json");
         fs::write(&file, "{}").unwrap();
         let (endpoint, rx) = spawn_capturing_mock_server().await;
@@ -439,7 +450,12 @@ mod tests {
             "api-key",
             file.to_str().unwrap(),
             false,
-            &["not-a-valid-header"],
+            &[
+                "not-a-valid-header",                                        // no colon
+                "Invalid Name: value",                                       // space in name
+                "X-Injected: value\r\nX-Smuggled-Header: evil", // CRLF injection in value
+                "X-Valid-Header: still-sent",
+            ],
         )
         .await;
 
@@ -451,6 +467,9 @@ mod tests {
 
         let request = rx.await.unwrap().to_lowercase();
         assert!(!request.contains("not-a-valid-header"));
+        assert!(!request.contains("invalid name"));
+        assert!(!request.contains("x-smuggled-header"));
+        assert!(request.contains("x-valid-header: still-sent"));
 
         fs::remove_dir_all(&dir).unwrap();
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -24,6 +24,7 @@ async fn post_fixture(
     api_key: &str,
     file: &str,
     insecure: bool,
+    extra_headers: &[&str],
 ) -> Result<FixtureResult, Errored> {
     let http_client = ClientBuilder::new().danger_accept_invalid_certs(insecure).build().unwrap();
     let canonical_path = fs::canonicalize(file).unwrap_or_default();
@@ -31,13 +32,25 @@ async fn post_fixture(
 
     match fs::read_to_string(canonical_path) {
         Ok(file_content) => {
-            let response = http_client
+            let mut request = http_client
                 .post(remote_endpoint)
                 .body(file_content)
                 .header("x-trento-apikey", api_key)
-                .header("Content-Type", "application/json")
-                .send()
-                .await;
+                .header("Content-Type", "application/json");
+
+            for raw_header in extra_headers {
+                match raw_header.split_once(':') {
+                    Some((name, value)) => {
+                        request = request.header(name.trim(), value.trim());
+                    }
+                    None => println!(
+                        "Ignoring malformed header '{}', expected format 'Key: Value'",
+                        raw_header
+                    ),
+                }
+            }
+
+            let response = request.send().await;
             match response {
                 Ok(res) => match res.status() {
                     StatusCode::ACCEPTED => {

--- a/src/run.rs
+++ b/src/run.rs
@@ -112,6 +112,7 @@ pub async fn run(
     scenario_label: String,
     scenarios: Vec<Scenario>,
     wait: u64,
+    extra_headers: &[&str],
 ) -> Result<(), ()> {
     let selected_scenario = scenarios
         .iter()
@@ -136,7 +137,8 @@ pub async fn run(
             let mut retryable: Vec<FixtureResult> = vec![];
 
             for file in full_scenario.iter() {
-                let execution_result = post_fixture(remote_endpoint, api_key, file, insecure).await;
+                let execution_result =
+                    post_fixture(remote_endpoint, api_key, file, insecure, extra_headers).await;
                 match execution_result {
                     Ok(FixtureResult::Retryable { file }) => {
                         retryable.push(FixtureResult::Retryable { file })
@@ -154,7 +156,7 @@ pub async fn run(
             for to_retry in retryable.iter() {
                 if let FixtureResult::Retryable { file } = to_retry {
                     println!("Retrying: {}", file);
-                    _ = post_fixture(remote_endpoint, api_key, file, insecure).await;
+                    _ = post_fixture(remote_endpoint, api_key, file, insecure, extra_headers).await;
                 }
             }
         }
@@ -213,6 +215,29 @@ mod tests {
             }
         });
         format!("http://{}", addr)
+    }
+
+    // Responds 202 to a single connection and hands the raw request bytes back
+    // to the caller — used to assert which headers were actually sent on the wire.
+    async fn spawn_capturing_mock_server() -> (String, tokio::sync::oneshot::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let mut buf = [0u8; 8192];
+                let n = socket.read(&mut buf).await.unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                let _ = socket
+                    .write_all(
+                        b"HTTP/1.1 202 Accepted\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                    )
+                    .await;
+                let _ = socket.shutdown().await;
+                let _ = tx.send(request);
+            }
+        });
+        (format!("http://{}", addr), rx)
     }
 
     // Accepts one connection per entry in `responses`, in order, and counts how many
@@ -297,7 +322,7 @@ mod tests {
         )
         .await;
 
-        let result = post_fixture(&endpoint, "api-key", file.to_str().unwrap(), false).await;
+        let result = post_fixture(&endpoint, "api-key", file.to_str().unwrap(), false, &[]).await;
 
         match result {
             Ok(FixtureResult::Success) => (),
@@ -318,7 +343,7 @@ mod tests {
         )
         .await;
 
-        let result = post_fixture(&endpoint, "api-key", file.to_str().unwrap(), false).await;
+        let result = post_fixture(&endpoint, "api-key", file.to_str().unwrap(), false, &[]).await;
 
         match result {
             Ok(FixtureResult::Unauthorized) => (),
@@ -339,7 +364,7 @@ mod tests {
         )
         .await;
 
-        let result = post_fixture(&endpoint, "api-key", file.to_str().unwrap(), false).await;
+        let result = post_fixture(&endpoint, "api-key", file.to_str().unwrap(), false, &[]).await;
 
         match result {
             Ok(FixtureResult::Retryable { file: retried_file }) => {
@@ -362,7 +387,7 @@ mod tests {
         )
         .await;
 
-        let result = post_fixture(&endpoint, "api-key", file.to_str().unwrap(), false).await;
+        let result = post_fixture(&endpoint, "api-key", file.to_str().unwrap(), false, &[]).await;
 
         match result {
             Ok(FixtureResult::Skippable) => (),
@@ -374,13 +399,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn post_fixture_sends_extra_headers() {
+        let dir = unique_test_dir("post_extra_headers");
+        let file = dir.join("fixture.json");
+        fs::write(&file, "{}").unwrap();
+        let (endpoint, rx) = spawn_capturing_mock_server().await;
+
+        let result = post_fixture(
+            &endpoint,
+            "api-key",
+            file.to_str().unwrap(),
+            false,
+            &["X-Custom-Header: hello", "X-Another:   world  "],
+        )
+        .await;
+
+        match result {
+            Ok(FixtureResult::Success) => (),
+            Ok(other) => panic!("expected Success, got {:?}", other),
+            Err(_) => panic!("expected Success, got an error"),
+        }
+
+        let request = rx.await.unwrap().to_lowercase();
+        assert!(request.contains("x-custom-header: hello"));
+        assert!(request.contains("x-another: world"));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn post_fixture_ignores_malformed_headers() {
+        let dir = unique_test_dir("post_malformed_headers");
+        let file = dir.join("fixture.json");
+        fs::write(&file, "{}").unwrap();
+        let (endpoint, rx) = spawn_capturing_mock_server().await;
+
+        let result = post_fixture(
+            &endpoint,
+            "api-key",
+            file.to_str().unwrap(),
+            false,
+            &["not-a-valid-header"],
+        )
+        .await;
+
+        match result {
+            Ok(FixtureResult::Success) => (),
+            Ok(other) => panic!("expected Success, got {:?}", other),
+            Err(_) => panic!("expected Success, got an error"),
+        }
+
+        let request = rx.await.unwrap().to_lowercase();
+        assert!(!request.contains("not-a-valid-header"));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
     async fn post_fixture_errors_when_file_is_missing() {
         let missing_file = unique_test_path("post_fixture_missing_file.json")
             .to_str()
             .unwrap()
             .to_string();
 
-        let result = post_fixture("http://127.0.0.1:1", "api-key", &missing_file, false).await;
+        let result = post_fixture("http://127.0.0.1:1", "api-key", &missing_file, false, &[]).await;
 
         match result {
             Err(Errored { file, reason }) => {
@@ -407,6 +489,7 @@ mod tests {
             "api-key",
             file.to_str().unwrap(),
             false,
+            &[],
         )
         .await;
 
@@ -433,6 +516,7 @@ mod tests {
                 "missing-scenario".to_string(),
                 vec![],
                 0,
+                &[],
             ),
         )
         .await
@@ -471,6 +555,7 @@ mod tests {
                 "my-scenario".to_string(),
                 vec![scenario],
                 0,
+                &[],
             ),
         )
         .await
@@ -513,6 +598,7 @@ mod tests {
                 "my-scenario".to_string(),
                 vec![scenario],
                 0,
+                &[],
             ),
         )
         .await
@@ -553,6 +639,7 @@ mod tests {
                 "my-scenario".to_string(),
                 vec![scenario],
                 0,
+                &[],
             ),
         )
         .await
@@ -561,6 +648,41 @@ mod tests {
         assert!(result.is_ok());
         // First attempt gets 400 (Retryable), then the retry pass posts it again.
         assert_eq!(counter.load(Ordering::SeqCst), 2);
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_forwards_extra_headers_to_every_request() {
+        let dir = unique_test_dir("run_extra_headers");
+        let file_a = dir.join("a.json");
+        fs::write(&file_a, "{}").unwrap();
+        let (endpoint, rx) = spawn_capturing_mock_server().await;
+
+        let scenario = Scenario {
+            label: "my-scenario".to_string(),
+            files: vec![file_a.to_str().unwrap().to_string()],
+            directories: vec![],
+        };
+
+        let result = timeout(
+            Duration::from_secs(5),
+            run(
+                &endpoint,
+                false,
+                "api-key",
+                "my-scenario".to_string(),
+                vec![scenario],
+                0,
+                &["X-Custom-Header: hello"],
+            ),
+        )
+        .await
+        .expect("run() timed out");
+
+        assert!(result.is_ok());
+        let request = rx.await.unwrap().to_lowercase();
+        assert!(request.contains("x-custom-header: hello"));
 
         fs::remove_dir_all(&dir).unwrap();
     }


### PR DESCRIPTION
### Description

This pull request adds support for sending extra HTTP headers with requests in the CLI tool, along with comprehensive tests to verify this behavior. The main changes include updating the CLI to accept repeated `--header` options, propagating these headers through the codebase, and ensuring they are included in all outgoing HTTP requests. Additional tests ensure both correct header forwarding and graceful handling of malformed headers.

- Added the `-H, --header <header>` CLI option to allow users to specify extra HTTP headers (as `Key: Value`), which can be repeated.
- Added new unit tests to verify that extra headers are sent with requests, and that malformed headers are ignored. Updated all existing tests to use the new function signatures. 
- Updated the `run` and `post_fixture` functions to accept and forward the extra headers parameter, ensuring all outgoing requests include user-supplied headers. Malformed headers are ignored with a warning.


Related #TRNT-4628

Fixes #13 

### How was this tested?

CI

### Documentation changes

Yes

### Additional information

N/A