### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,77 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:1.76 as builder
+ARG RUST_VERSION=1.96
+ARG OS_VER=15.7
+
+# Base build image
+FROM registry.suse.com/bci/rust:${RUST_VERSION} AS builder
 
 WORKDIR /home/photofinish/
 
-COPY . .
-RUN cargo build --release
+RUN set -euo pipefail; \
+    zypper -n install --no-recommends libopenssl-devel
 
-FROM registry.suse.com/bci/rust:latest
+# Build dependencies first and cache them
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir -p src && \
+    printf 'fn main() {}\n' > src/main.rs
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/home/photofinish/target \
+    cargo build --release
 
-WORKDIR /home/photofinish/
-COPY --from=builder /home/photofinish/target/release/photofinish .
+# Copy the actual source code and build the final binary
+COPY src ./src
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/home/photofinish/target \
+    touch src/main.rs && \
+    cargo build --release && \
+    cp target/release/photofinish /home/photofinish/photofinish
+
+FROM registry.suse.com/bci/bci-base:${OS_VER}
+
+ARG OS_VER
+
+# Copy the built binary from the builder stage
+COPY --from=builder /home/photofinish/photofinish /home/photofinish/photofinish
+
+# Install runtime dependencies
+RUN set -euo pipefail; \
+    zypper -n install --no-recommends ca-certificates libopenssl3
+
+# Cleanup logs and temporary files
+RUN set -euo pipefail; zypper -n clean -a; \
+    rm -rf {/target,}/var/log/{alternatives.log,lastlog,tallylog,zypper.log,zypp/history,YaST2}; \
+    rm -rf {/target,}/run/*; \
+    rm -f {/target,}/etc/{shadow-,group-,passwd-,.pwd.lock}; \
+    rm -f {/target,}/usr/lib/sysimage/rpm/.rpm.lock; \
+    rm -f {/target,}/var/lib/zypp/AnonymousUniqueId; \
+    rm -f {/target,}/var/lib/zypp/AutoInstalled; \
+    rm -f {/target,}/var/cache/ldconfig/aux-cache
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.suse.trento
+LABEL org.opencontainers.image.authors="https://github.com/trento-project/photofinish/graphs/contributors"
+LABEL org.opencontainers.image.title="Photofinish"
+LABEL org.opencontainers.image.description="CLI tool to replay events and inject fixtures"
+LABEL org.opencontainers.image.documentation="https://github.com/trento-project/photofinish/blob/main/README.adoc"
+LABEL org.opencontainers.image.version="devel"
+LABEL org.opencontainers.image.url="https://github.com/trento-project/photofinish"
+# LABEL org.opencontainers.image.created="" # Set by GHA, no need to set here
+LABEL org.opencontainers.image.vendor="SUSE LLC"
+LABEL org.opencontainers.image.source="https://github.com/trento-project/photofinish"
+LABEL org.opencontainers.image.ref.name="${OS_VER}-devel"
+LABEL org.opensuse.reference="registry.suse.com/bci/bci-base:${OS_VER}"
+LABEL org.openbuildservice.disturl="https://github.com/trento-project/photofinish/pkgs/container/photofinish"
+# endlabelprefix
+LABEL org.opencontainers.image.base.name="registry.suse.com/bci/bci-base:${OS_VER}"
+LABEL org.opencontainers.image.base.digest="latest"
+
 WORKDIR /data
+
 VOLUME ["/data"]
+
+USER 1001
+
 ENTRYPOINT ["/home/photofinish/photofinish"]

--- a/README.adoc
+++ b/README.adoc
@@ -36,8 +36,10 @@ Please refer to `+photofinish help+` for more commands.
 
 [source,sh]
 ----
-$ docker run --network host -v <photofinish-toml-dir>:/data ghcr.io/trento-project/photofinish run <scenario-name> "<api-token>" -u <api-collect-endpoint>
+$ docker run --network host -v PHOTOFINISH_TOML_DIR:/data ghcr.io/trento-project/photofinish run SCENARIO_NAME "API_TOKEN" -u API_COLLECT_ENDPOINT
 ----
+
+Replace `+PHOTOFINISH_TOML_DIR+`, `+SCENARIO_NAME+`, `+API_TOKEN+` and `+API_COLLECT_ENDPOINT+` with your actual values before running the command.
 
 == Example of `+.photofinish.toml+`
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,22 +1,18 @@
 = Trento Photofinish
 
-This tiny CLI tool aims to fulfill the need to replay some events and
-get fixtures.
+This tiny CLI tool aims to fulfill the need to replay some events and get fixtures.
 
-Photofinish reads a `+.photofinish.toml+` file in the current working
-directory and:
+Photofinish reads a `+.photofinish.toml+` file in the current working directory and:
 
 * It outputs the fixture sets in the TOML file;
-* It issues POST requests against the endpoint we give (default:
-`+http://localhost:8081/api/collect+`) with the content of the fixture
-files as request body.
+* It issues POST requests against the endpoint we give (default: `+http://localhost:8081/api/collect+`) with the content of the fixture files as request body.
 
 == Photofinish usage
 
 [source,sh]
 ----
 $ photofinish run --help
-photofinish-run 
+photofinish-run
 injects a specific set of events
 
 USAGE:
@@ -34,6 +30,14 @@ OPTIONS:
 ----
 
 Please refer to `+photofinish help+` for more commands.
+
+
+== Using the container image
+
+[source,sh]
+----
+$ docker run --network host -v <photofinish-toml-dir>:/data ghcr.io/trento-project/photofinish run <scenario-name> "<api-token>" -u <api-collect-endpoint>
+----
 
 == Example of `+.photofinish.toml+`
 
@@ -62,4 +66,12 @@ $ photofinish run first-test-scenario
 Successfully POSTed file: ../../test/fixtures/discovery/host/expected_published_host_discovery.json
 Successfully POSTed file: ../../test/fixtures/discovery/sap_system/sap_system_discovery_application.json
 Successfully POSTed file: ../../test/fixtures/discovery/subscriptions/expected_published_subscriptions_discovery.json
+----
+
+== Building and running the container image
+
+[source,sh]
+----
+$ docker build -t photofinish .
+$ docker run --rm -v .:/data photofinish run first-test-scenario
 ----


### PR DESCRIPTION
### Description

This pull request significantly refactors the `Dockerfile` to improve build efficiency, security, and maintainability. The changes introduce a multi-stage build using SUSE's official Rust and base images, optimize dependency caching, and enhance the final image by reducing its size and attack surface.

- Switched to a multi-stage build using `registry.suse.com/bci/rust` for building and `bci-base` for the runtime, instead of the generic Rust image. This results in a smaller and more secure final image.
- Optimized dependency installation and caching by separating the build of dependencies from the actual source code, reducing rebuild times when dependencies don't change.
- Added installation of only the minimal required runtime dependencies (`ca-certificates`, `libopenssl3`) and cleaned up package manager caches and sensitive files to minimize the image footprint and remove unnecessary data.
- Changed the default user to a non-root user (`USER 1001`) to improve container security.
- Added comprehensive Open Container Initiative (OCI) and SUSE-specific labels for better documentation and traceability of the built image.

Related #TRNT-4628

### How was this tested?

IRL

### Documentation changes

No

### Additional information

This mimics the Dockerfile we use in other projects we have in Rust (c.f., https://github.com/trento-project/tlint/blob/main/Dockerfile)